### PR TITLE
Remove the rcon print, to prevent players being spammed 

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -16,7 +16,6 @@ commands.add_command("collectdata", nil, function (params)
 	trains.collect_trains()
 
 	if params.parameter == "rcon" then
-		game.print("RCON!")
 		rcon.print(game.table_to_json(global.output))
 	else
 		game.write_file("game.prom", game.table_to_json(global.output), false)


### PR DESCRIPTION
I'm new to factorio mods and RCON so it's possible I'm misinterpreting something here.

I'd like to use this mod + RCON to remotely be able to generate and fetch the stats (via the RCON connection) instead of picking them up from a disk file.

This seems to work OK, I can get the JSON data by issuing /collectdata, but it also prints "RCON!" and that seems to appear on each connected players game screen as well.

